### PR TITLE
Use -DSKIP_optix=true to fix cmake warning

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -12,7 +12,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-      -DSKIP_optix=true \
+	    -DSKIP_optix=true \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_install:

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -12,6 +12,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+      -DSKIP_optix=true \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_install:


### PR DESCRIPTION
* Backport https://github.com/gazebo-release/gz-rendering6-release/pull/7